### PR TITLE
Support Python 3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,10 @@ jobs:
     strategy:
       matrix:
         tox_env:
+         - py38-pytest7
+         - py38-pytest8
+         - py39-pytest7
+         - py39-pytest8
          - py310-pytest7
          - py310-pytest8
          - py311-pytest7

--- a/README.md
+++ b/README.md
@@ -43,11 +43,12 @@ Runtime : min   11.66s, max   12.59s, average 12.10s
 
 ## Development
 
-[Poetry](https://python-poetry.org/) (dependencies) and [pre-commit](https://pre-commit.com/) (coding standards) are required for development.
+[Poetry](https://python-poetry.org/) is required for development.
 
 ```shell
-$ poetry install
-$ pre-commit install
+$ poetry install --with dev
+$ poetry run pre-commit install
+$ poetry shell
 ```
 
 ## Thanks

--- a/README.md
+++ b/README.md
@@ -43,12 +43,11 @@ Runtime : min   11.66s, max   12.59s, average 12.10s
 
 ## Development
 
-[Poetry](https://python-poetry.org/) is required for development.
+[Poetry](https://python-poetry.org/) (dependencies) and [pre-commit](https://pre-commit.com/) (coding standards) are required for development.
 
 ```shell
-$ poetry install --with dev
-$ poetry run pre-commit install
-$ poetry shell
+$ poetry install
+$ pre-commit install
 ```
 
 ## Thanks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ pytest-xdist = "^3.3"
 [tool.poetry.group.dev.dependencies]
 black = "^23.9.1"
 ruff = "^0.0.291"
-pre-commit = "^3.3.0"
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pytest-xdist-worker-stats"
-version = "0.1.5"
+version = "0.1.6"
 description = "A pytest plugin to list worker statistics after a xdist run."
 authors = ["Mikuláš Poul <mikulaspoul@gmail.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,8 @@ classifiers = [
     "Topic :: Software Development :: Testing",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -26,13 +28,14 @@ keywords = ["pytest", "xdist", "pytest-xdist"]
 pytest-xdist-worker-stats = "pytest_xdist_worker_stats"
 
 [tool.poetry.dependencies]
-python = ">3.9"
+python = ">=3.8"
 pytest = ">7.3.2"
 pytest-xdist = "^3.3"
 
 [tool.poetry.group.dev.dependencies]
 black = "^23.9.1"
 ruff = "^0.0.291"
+pre-commit = "^3.3.0"
 
 [build-system]
 requires = ["poetry-core"]
@@ -40,7 +43,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.black]
 line-length = 120
-target_version = ['py310', 'py311', 'py312']
+target_version = ['py38', 'py39', 'py310', 'py311', 'py312']
 include = '\.pyi?$'
 exclude = '''
 (
@@ -83,7 +86,7 @@ select = [
 ]
 
 line-length = 120
-target-version = "py310"
+target-version = "py38"
 
 # Never enforce...
 ignore = [

--- a/pytest_xdist_worker_stats/__init__.py
+++ b/pytest_xdist_worker_stats/__init__.py
@@ -1,3 +1,3 @@
 from .options import pytest_configure  # noqa: F401
 
-__version__ = "0.1.2"
+__version__ = "0.1.6"


### PR DESCRIPTION
There are still a number of legacy applications that use python 3.8. It is meaningful to maintain support as 3.8 has not yet reached end-of-life: https://devguide.python.org/versions/